### PR TITLE
fix(front): Email regular expression checking is overly strict

### DIFF
--- a/global/helpers/validate.ts
+++ b/global/helpers/validate.ts
@@ -1,14 +1,14 @@
 import { addNotification } from "../store/notifications_model"
 
 export const validateEmailOrPhone = (value: string) =>
-	/^(?:\d{11}|\w+@\w+\.\w{2,3})$/.test(value) === false
+	/^(?:\d{11}|\S+@\S+\.\S+)$/.test(value) === false
 		? 'Пожалуйста следуйте формату: user_email@email.com или 79889998889'
 		: true
 export const isPhoneNumber = (value: string | null) => {
 	return value && /\d{11}/.test(value) ? value : null
 }
 export const isEmail = (value: string | null) => {
-	return value && /\w+@\w+\.\w{2,3}/.test(value) ? value : null
+	return value && /\S+@\S+\.\S+/.test(value) ? value : null
 }
 export const isTypeOfFileAreImage = (value: string) => {
 	if (!value) return;


### PR DESCRIPTION
This PR fixes an issue with email validation regex in the front-end. The old regex was too strict and rejected some valid emails. I updated it to be more flexible and user-friendly.

The new regular expression is more lenient, which means it might allow some erroneous email addresses. However, it covers almost all valid email formats. For instance, emails with a dot in the local part were previously rejected but are now accepted. Since you rely on email confirmation as the final step of verification, this change should not cause any critical issues.


Old regex: /^\w+@\w+\.\w{2,3}$/
New regex: /^\S+@\S+\.\S+$/

You can also check these expressions with a simple test with a list of mails:
```js
// List of Valid Email Addresses
const valid = [
    'email@example.com',
    'firstname.lastname@example.com',
    'email@subdomain.example.com',
    'firstname+lastname@example.com',
    'email@123.123.123.123',
    'email@[123.123.123.123]',
    '"email"@example.com',
    '1234567890@example.com',
    'email@example-one.com',
    '_______@example.com',
    'email@example.name',
    'email@example.museum',
    'email@example.co.jp',
    'firstname-lastname@example.com',
];

// List of Strange Valid Email Addresses
const strangeValid = [
    'much.”more\ unusual”@example.com',
    'very.unusual.”@”.unusual.com@example.com',
    'very.”(),: ;<>[]”.VERY.”very@\\ "very”.unusual@strange.example.com',
];

// List of Invalid Email Addresses
const invalid = [
    'plainaddress',
    '#@%^%#$@#$@#.com',
    '@example.com',
    'Joe Smith <email@example.com>',
    'email.example.com',
    'email@example@example.com',
    '.email@example.com',
    'email.@example.com',
    'email..email@example.com',
    'あいうえお@example.com',
    'email@example.com (Joe Smith)',
    'email@example',
    'email@-example.com',
    'email@example.web',
    'email@111.222.333.44444',
    'email@example..com',
    'Abc..123@example.com',
];

// List of Strange Invalid Email Addresses
const strangeInvalid = [
    '”(),:;<>[\]@example.com',
    'just”not”right@example.com',
    'this\ is"really"not\allowed@example.com',
];


const check = (regex) => {
    const checkList = { invalid, valid, strangeInvalid, strangeValid };
    const result = [0, 0];
    Object.entries(checkList).forEach(([name, list], i) => {
        console.log('>>', name, '>>');
        list.forEach((email, x) => console.log(`${i % 2 ? 'valid' : 'invalid'} (${x + 1}): `, regex.test(email) == i % 2 ? 'ok' : 'fail'));
    })
    return result;
}

const r1 = /\w+@\w+\.\w{2,3}/;
const r2 = /\S+@\S+\.\S+/;

console.log('Old regex:');
check(r1);

console.log('\n\n\n');

console.log('New regex:');
check(r2);
```